### PR TITLE
Bring hotfixes from release/public-v1 back to master (CCPP changes)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,13 @@
 	branch = dev/emc
 [submodule "ccpp/framework"]
 	path = ccpp/framework
-	url = https://github.com/NCAR/ccpp-framework
-	branch = master
+	#url = https://github.com/NCAR/ccpp-framework
+	#branch = master
+	url = https://github.com/climbfuji/ccpp-framework
+	branch = bugfixes_from_public_release
 [submodule "ccpp/physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = master
+	#url = https://github.com/NCAR/ccpp-physics
+	#branch = master
+	url = https://github.com/climbfuji/ccpp-physics
+	branch = bugfixes_from_public_release

--- a/ccpp/suites/suite_FV3_CPT_v0.xml
+++ b/ccpp/suites/suite_FV3_CPT_v0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_CPT_v0" lib="ccppphys" ver="3">
+<suite name="FV3_CPT_v0" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_RRTMGP.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_RRTMGP.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_RRTMGP" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_RRTMGP" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_coupled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_coupled" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_coupled" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_csawmg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_csawmg" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_csawmg" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_csawmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_csawmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_csawmgshoc" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_csawmgshoc" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_gfdlmp" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_gfdlmp" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_noahmp.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_noahmp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_gfdlmp_noahmp" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_gfdlmp_noahmp" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_gfdlmp_regional" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_gfdlmp_regional" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional_c768.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_gfdlmp_regional_c768.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_gfdlmp_regional_c768" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_gfdlmp_regional_c768" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_h2ophys.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_h2ophys.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_h2ophys" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_h2ophys" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_myj.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_myj.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_myj" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_myj" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_ntiedtke.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_ntiedtke.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_ntiedtke" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_ntiedtke" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_ozphys_2015.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_ozphys_2015.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_ozphys_2015" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_ozphys_2015" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_sas.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_sas.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_sas" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_sas" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_satmedmf.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_satmedmf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_satmedmf" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_satmedmf" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_satmedmf_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_satmedmf_coupled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_satmedmf_coupled" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_satmedmf_coupled" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_satmedmfq.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_satmedmfq.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_satmedmfq" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_satmedmfq" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_shinhong.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_shinhong.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_shinhong" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_shinhong" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_stretched.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_stretched.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_stretched" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_stretched" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_2017_ysu.xml
+++ b/ccpp/suites/suite_FV3_GFS_2017_ysu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_2017_ysu" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_2017_ysu" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_cpld_rasmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_cpld_rasmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_cpld_rasmgshoc" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_cpld_rasmgshoc" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_cpldnst_rasmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_cpldnst_rasmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_cpldnst_rasmgshoc" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_cpldnst_rasmgshoc" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_rasmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_rasmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_rasmgshoc" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_rasmgshoc" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_gf.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_gf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_gf" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15_gf" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_gf_thompson.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_gf_thompson.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_gf_thompson" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15_gf_thompson" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_mynn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_mynn" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15_mynn" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_ras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_ras.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_ras" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15_ras" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_rasmgshoc.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_rasmgshoc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_rasmgshoc" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15_rasmgshoc" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_thompson" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15_thompson" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15_thompson_mynn.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15_thompson_mynn" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15_thompson_mynn" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15p2.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15p2" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15p2" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15p2_coupled.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_coupled.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15p2_coupled" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15p2_coupled" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15p2_no_nsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15p2_no_nsst.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_GFS_v15p2_no_nsst" lib="ccppphys" ver="4">
+  <!-- <init></init> -->
+  <group name="fast_physics">
+    <subcycle loop="1">
+      <scheme>fv_sat_adj</scheme>
+    </subcycle>
+  </group>
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>rrtmg_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>sfc_diff</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_ocean</scheme>
+      <scheme>lsm_noah</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>GFS_PBL_generic_pre</scheme>
+      <scheme>hedmf</scheme>
+      <scheme>GFS_PBL_generic_post</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>cires_ugwp</scheme>
+      <scheme>cires_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>ozphys_2015</scheme>
+      <scheme>h2ophys</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>samfdeepcnv</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>GFS_SCNV_generic_pre</scheme>
+      <scheme>samfshalcnv</scheme>
+      <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>gfdl_cloud_microphys</scheme>
+      <scheme>GFS_MP_generic_post</scheme>
+      <scheme>maximum_hourly_diagnostics</scheme>
+    </subcycle>
+  </group>
+  <group name="stochastics">
+    <subcycle loop="1">
+      <scheme>GFS_stochastics</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/ccpp/suites/suite_FV3_GFS_v15plus.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15plus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15plus" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15plus" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v15plusras.xml
+++ b/ccpp/suites/suite_FV3_GFS_v15plusras.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v15plusras" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v15plusras" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16_csawmg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v16_csawmg" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v16_csawmg" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16beta.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16beta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GFS_v16beta" lib="ccppphys" ver="3">
+<suite name="FV3_GFS_v16beta" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="fast_physics">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GFS_v16beta_no_nsst.xml
+++ b/ccpp/suites/suite_FV3_GFS_v16beta_no_nsst.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="FV3_GFS_v16beta_no_nsst" lib="ccppphys" ver="4">
+  <!-- <init></init> -->
+  <group name="fast_physics">
+    <subcycle loop="1">
+      <scheme>fv_sat_adj</scheme>
+    </subcycle>
+  </group>
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>rrtmg_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw_pre</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>sfc_diff</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_ocean</scheme>
+      <scheme>lsm_noah</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>GFS_PBL_generic_pre</scheme>
+      <scheme>satmedmfvdifq</scheme>
+      <scheme>GFS_PBL_generic_post</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>cires_ugwp</scheme>
+      <scheme>cires_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>rayleigh_damp</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>ozphys_2015</scheme>
+      <scheme>h2ophys</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>samfdeepcnv</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>GFS_SCNV_generic_pre</scheme>
+      <scheme>samfshalcnv</scheme>
+      <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>gfdl_cloud_microphys</scheme>
+      <scheme>GFS_MP_generic_post</scheme>
+      <scheme>maximum_hourly_diagnostics</scheme>
+    </subcycle>
+  </group>
+  <group name="stochastics">
+    <subcycle loop="1">
+      <scheme>GFS_stochastics</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/ccpp/suites/suite_FV3_GSD_SAR.xml
+++ b/ccpp/suites/suite_FV3_GSD_SAR.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_SAR" lib="ccppphys" ver="3">
+<suite name="FV3_GSD_SAR" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GSD_noah.xml
+++ b/ccpp/suites/suite_FV3_GSD_noah.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_noah" lib="ccppphys" ver="3">
+<suite name="FV3_GSD_noah" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GSD_v0.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_v0" lib="ccppphys" ver="3">
+<suite name="FV3_GSD_v0" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_GSD_v0_drag_suite.xml
+++ b/ccpp/suites/suite_FV3_GSD_v0_drag_suite.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_GSD_v0_drag_suite" lib="ccppphys" ver="3">
+<suite name="FV3_GSD_v0_drag_suite" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/ccpp/suites/suite_FV3_HAFS_ferhires_update_moist.xml
+++ b/ccpp/suites/suite_FV3_HAFS_ferhires_update_moist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<suite name="FV3_HAFS_ferhires_update_moist" lib="ccppphys" ver="3">
+<suite name="FV3_HAFS_ferhires_update_moist" lib="ccppphys" ver="4">
   <!-- <init></init> -->
   <group name="time_vary">
     <subcycle loop="1">

--- a/gfsphysics/GFS_layer/GFS_physics_driver.F90
+++ b/gfsphysics/GFS_layer/GFS_physics_driver.F90
@@ -2135,7 +2135,7 @@ module module_physics_driver
 !*## CCPP ##
         Diag%dlwsfci(i) = adjsfcdlw(i)
         Diag%ulwsfci(i) = adjsfculw(i)
-!## CCPP ##* dcyc2.f/dcyc2t3_post_run
+!## CCPP ##* GFS_surface_composites.F90/GFS_surface_composites_inter_run
         Diag%uswsfci(i) = adjsfcdsw(i) - adjsfcnsw(i)
 !*## CCPP ##
         Diag%dswsfci(i) = adjsfcdsw(i)


### PR DESCRIPTION
Updates for CCPP suites, `.gitmodules` and submodule pointers for ccpp-framework and ccpp-physics. These submodule pointers may need to be updated again if changes are made to the branches bugfixes_from_public_release in @climbfuji's forks of ccpp-framework and ccpp-physics.