### PR TITLE
update ccpp/physics submodule pointer and .gitmodules for testing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = main
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/NCAR/ccpp-physics
-  branch = main
+  url = https://github.com/grantfirl/ccpp-physics
+  branch = sfc_flux_spec_update
+  #url = https://github.com/NCAR/ccpp-physics
+  #branch = main
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
At this morning's UFS code management meeting, @junwang-noaa requested that https://github.com/NCAR/ccpp-physics/pull/870 be combined with this for the UFS commit queue. This PR updates fv3atm to point to the referenced ccpp-physics PR branch. The ccpp-physics changes in that PR branch are completely ignored by UFS and will not affect any RTs.
