### PR TITLE
ESMF logging and tracing updates around RouteHandle setup

### DIFF
--- a/fv3_cap.F90
+++ b/fv3_cap.F90
@@ -179,7 +179,7 @@ module fv3atm_cap_mod
     type(ESMF_Clock)                       :: clock
 
     character(len=10)                      :: value
-    character(240)                         :: msgString
+    character(400)                         :: msgString
     logical                                :: isPresent, isSet
     type(ESMF_VM)                          :: vm, wrtVM
     type(ESMF_Time)                        :: currTime, startTime
@@ -786,7 +786,7 @@ module fv3atm_cap_mod
 
             call ESMF_LogSet(flush=.true., rc=rc)
 
-            write(msgString,"(A,I2.2,',',I2.2,A)") "RH creation for wrtFB(",j,i, ") ...."
+            write(msgString,"(A,I2.2,',',I2.2,A)") "RH creation for wrtFB(",j,i, ") ...."//trim(fcstItemNameList(j))
             call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
 
             if (i==1) then


### PR DESCRIPTION
Supersedes https://github.com/NOAA-EMC/fv3atm/pull/901. 

## Description

The changes in this PR were made during the debugging effort when testing recent ESMF beta tags. This PR wants to preserve the diagnostic improvements.

The code changes are purely focused at providing improved diagnostic. They do not change the actual implementation of the procedure of setting up the RouteHandles. A few changes to what gets written to ESMF log files during the setup of RouteHandles between FCST and WRT components. Also add a few more ESMF trace regions for more complete coverage in the ESMF profile.
