### PR TITLE
fix RRFSv1 restart reproducibility with saSAS deep convection 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = production/RRFS.v1
+  url = https://github.com/JiliDong-NOAA/ccpp-physics    
+  branch = sigmab_restart_fix
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP


### PR DESCRIPTION
## Description

This PR will restore restart reproducibility of RRFSv1 when using saSAS deep convection and progsigma. The change will add the correct logic when initializing sigmab (the updraft area fraction). Although not being turned on in RRFSv1, saSAS shallow convection is also modified accordingly for consistency.

This PR has no impact on warm start runs.

### Issue(s) addressed

fix saSAS related restart reproducibility issue in RRFSv1


## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>

