### PR TITLE
Acsnow restart fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,8 +8,10 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-  url = https://github.com/ufs-community/ccpp-physics
-  branch = production/RRFS.v1
+#  url = https://github.com/ufs-community/ccpp-physics
+#  branch = production/RRFS.v1
+  url = https://github.com/JiliDong-NOAA/ccpp-physics    
+  branch = sigmab_restart_fix
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,10 +8,8 @@
   branch = production/RRFS.v1
 [submodule "ccpp/physics"]
   path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = production/RRFS.v1
-  url = https://github.com/JiliDong-NOAA/ccpp-physics    
-  branch = sigmab_restart_fix
+  url = https://github.com/ufs-community/ccpp-physics
+  branch = production/RRFS.v1
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP

--- a/io/fv3atm_restart_io.F90
+++ b/io/fv3atm_restart_io.F90
@@ -405,6 +405,8 @@ contains
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%tsnow_ice)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%snowfallac_land)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%snowfallac_ice)
+        call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%acsnow_land)
+        call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%acsnow_ice)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%sfalb_lnd)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%sfalb_lnd_bck)
         call copy_from_GFS_Data(ii1,jj1,isc,jsc,nt,temp2d,GFS_Data(nb)%Sfcprop%sfalb_ice)

--- a/io/fv3atm_sfc_io.F90
+++ b/io/fv3atm_sfc_io.F90
@@ -123,9 +123,9 @@ contains
     endif
     if (Model%lsm == Model%lsm_ruc .and. warm_start) then
       if (Model%rdlai) then
-        nvar2r = 13
+        nvar2r = 15
       else
-        nvar2r = 12
+        nvar2r = 14
       endif
       nvar3  = 5
     else
@@ -534,6 +534,8 @@ contains
       nt=nt+1 ; sfc%name2(nt) = 'tsnow_ice'
       nt=nt+1 ; sfc%name2(nt) = 'snowfall_acc_land'
       nt=nt+1 ; sfc%name2(nt) = 'snowfall_acc_ice'
+      nt=nt+1 ; sfc%name2(nt) = 'acsnow_land'
+      nt=nt+1 ; sfc%name2(nt) = 'acsnow_ice'
       nt=nt+1 ; sfc%name2(nt) = 'sfalb_lnd'
       nt=nt+1 ; sfc%name2(nt) = 'sfalb_lnd_bck'
       nt=nt+1 ; sfc%name2(nt) = 'sfalb_ice'
@@ -1051,6 +1053,8 @@ contains
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%tsnow_ice)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%snowfallac_land)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%snowfallac_ice)
+        call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%acsnow_land)
+        call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%acsnow_ice)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%sfalb_lnd)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%sfalb_lnd_bck)
         call GFS_Data_transfer(reading,ii1,jj1,isc,jsc,nt,sfc%var2,Sfcprop(nb)%sfalb_ice)


### PR DESCRIPTION
## Description

This PR will fix the restart reproducibility of snow water equivalent accumulation by adding acsnow_land and acsnow_ice to the RESTART sfc_data.nc. I am not entirely sure if nvar2r or nvar2m need to be updated. Currently I choose to update nvar2r. And it seems working fine.   


### Issue(s) addressed

Restore the restart reproducibility of snow water equivalent accumulation


## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>

