### PR TITLE
Restart fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,13 +6,11 @@
   path = ccpp/framework
   url = https://github.com/NCAR/ccpp-framework
   branch = production/RRFS.v1
-[submodule "ccpp/physics"]
-  path = ccpp/physics
-#  url = https://github.com/ufs-community/ccpp-physics
-#  branch = production/RRFS.v1
-  url = https://github.com/JiliDong-NOAA/ccpp-physics    
-  branch = sigmab_restart_fix
 [submodule "upp"]
   path = upp
   url = https://github.com/NOAA-EMC/UPP
   branch = develop
+[submodule "ccpp/physics"]
+  path = ccpp/physics
+  url = https://github.com/JiliDong-NOAA/ccpp-physics.git
+  branch = sigmab_restart_fix


### PR DESCRIPTION
## Description

Fix RRFS ensemble restart reproducibility by correcting Grell-Freitas initialization logic



### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!)
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>



## Testing

How were these changes tested?  
What compilers / HPCs was it tested with?  
Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  
Have the ufs-weather-model regression test been run? On what platform?  
- Will the code updates change regression test baseline? If yes, why? Please show the baseline directory below.
- Please commit the regression test log files in your ufs-weather-model branch


## Dependencies

If testing this branch requires non-default branches in other repositories, list them.
Those branches should have matching names (ideally)

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on noaa-emc/nems/pull/<pr_number>
- waiting on noaa-emc/fv3atm/pull/<pr_number>

